### PR TITLE
better feedback with missing json (context) files

### DIFF
--- a/tasks/static_handlebars.js
+++ b/tasks/static_handlebars.js
@@ -240,6 +240,9 @@ module.exports = function(grunt) {
 
     function getResourceText(name) {
         grunt.log.debug('Get resource text:', name, process.cwd());
+        if(!grunt.file.exists(name)){
+          grunt.fail.warn('Could not retrieve file "'+name+'" \nThis is needed for defining the context of a Handlebars template.\nSee documentation for more information.');
+        }
         return grunt.file.read(name, { encoding: 'utf8' });
     }
 


### PR DESCRIPTION
no extends-errors, but the correct file that is missing. "grunt xxxx
-d" also helps.
