### PR TITLE
Allow users to explicitly set partialPath and helpersPath

### DIFF
--- a/tasks/static_handlebars.js
+++ b/tasks/static_handlebars.js
@@ -544,8 +544,8 @@ module.exports = function(grunt) {
         if(parentDirectory === ''){
             parentDirectory = '.';
         }
-        options.assets.helperPath = parentDirectory+'/helpers/';
-        options.assets.partialPath = parentDirectory+'/partials/';
+        options.assets.helperPath = options.assets.helpersPath || parentDirectory+'/helpers/';
+        options.assets.partialPath = options.assets.partialPath || parentDirectory+'/partials/';
 
         //retrieve assetsUrlPrefix if available
         if(grunt.file.exists(options.assets.templatesPath+'/base.json')){


### PR DESCRIPTION
This small change adds greater flexibility by allowing the user to explicitly set paths for partials and helpers in the task config section in the grunt file.
